### PR TITLE
firewalld blocking custom ssh ports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ security_autoupdate_mail_on_error: true
 
 security_fail2ban_enabled: true
 security_fail2ban_custom_configuration_template: "jail.local.j2"
+security_firewalld_custom_ssh_configuration_template: "ssh.xml.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,10 @@
   when:
     - security_fail2ban_enabled | bool
 
+- include_tasks: firewalld-configuration.yml
+  when:
+    - security_fail2ban_enabled | bool
+
 - name: Ensure fail2ban is running and enabled on boot.
   service: name=fail2ban state=started enabled=yes
   when: security_fail2ban_enabled | bool


### PR DESCRIPTION
I had another problem.  fail2ban installs firewalld as a dependency.  By default firewalld has the ssh port open, but as a port 22.  So besides configuring the fail2ban port, also firewalld's ssh service needs to have the custom port defined.

I am not sure whether this is the best way to go.  Sometimes I wonder if changing the definition of ssh in /etc/services would be easier way to go.